### PR TITLE
[OSC-870] - Fix Package Versioning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,11 @@
-version: 1.0.{build}
 image: Visual Studio 2017
 build_script:
 - cmd: >-
-    dotnet build -c release src/PageUp.CldrPackager/PageUp.CldrPackager.csproj
+    dotnet build -c release src/Main.sln
 
     dotnet test src/PageUp.CldrPackager.Test/PageUp.CldrPackager.Test.csproj
 
-    dotnet pack -c release src/PageUp.CldrPackager/PageUp.CldrPackager.csproj  /p:Version=%APPVEYOR_BUILD_VERSION% 
+    dotnet pack -c release src/PageUp.CldrPackager/PageUp.CldrPackager.csproj 
 
 artifacts: 
   - path: ./src/PageUp.CldrPackager/bin/release/*.nupkg

--- a/src/PageUp.CldrPackager/PageUp.CldrPackager.csproj
+++ b/src/PageUp.CldrPackager/PageUp.CldrPackager.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Version>1.0.2</Version>
+  </PropertyGroup>
+  <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
(a) use app version for publishing nuget package instead of CI build version (b) update & publish version 1.0.2