### PR TITLE
Users/ben/tests fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,14 @@
 version: 1.0.{build}
 image: Visual Studio 2017
 build_script:
+before_build:
+- ps: >-
+    Install-Product node ''
+
+    node --version
+
+    npm --version
+
 - cmd: >-
     dotnet build -c release src/Main.sln
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-build_script:
 before_build:
 - ps: >-
     Install-Product node ''
@@ -9,6 +8,7 @@ before_build:
 
     npm --version
 
+build_script:
 - cmd: >-
     dotnet build -c release src/Main.sln
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,16 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-before_build:
-- ps: >-
-    Install-Product node ''
-
-    node --version
-
-    npm --version
+install:
+  - ps: Install-Product node ''
+  - node --version
+  - npm --version
 
 build_script:
-- cmd: >-
-    dotnet build -c release src/Main.sln
+  - ps: dotnet build -c release src/Main.sln
+  - ps: dotnet pack -c release src/PageUp.CldrPackager/PageUp.CldrPackager.csproj 
 
-    dotnet test src/PageUp.CldrPackager.Test/PageUp.CldrPackager.Test.csproj
-
-    dotnet pack -c release src/PageUp.CldrPackager/PageUp.CldrPackager.csproj 
+test_script:
+  - ps: dotnet test src/PageUp.CldrPackager.Test/PageUp.CldrPackager.Test.csproj
 
 artifacts: 
   - path: ./src/PageUp.CldrPackager/bin/release/*.nupkg

--- a/src/PageUp.CldrPackager.Test/CldrDataVersionTest.cs
+++ b/src/PageUp.CldrPackager.Test/CldrDataVersionTest.cs
@@ -12,7 +12,7 @@ namespace PageUp.CldrPackager.Test
             var patterns = new PatternCollectionBuilder().Build();
             var builder = new CldrDataBuilder();
 
-            var data = builder.Build(TestSettings.CldrFileInputDirectory, patterns);
+            var data = builder.Build(TestSettings.GetCldrFileInputDirectoryPath(), patterns);
 
             Assert.NotNull(data.PageUpVersion);
             Assert.NotEmpty(data.PageUpVersion);

--- a/src/PageUp.CldrPackager.Test/DateFormatTest.cs
+++ b/src/PageUp.CldrPackager.Test/DateFormatTest.cs
@@ -18,7 +18,7 @@ namespace PageUp.CldrPackager.Test
             var patterns = new PatternCollectionBuilder().Build();
 
             var builder = new CldrDataBuilder();
-            _data = builder.Build(TestSettings.CldrFileInputDirectory, patterns);
+            _data = builder.Build(TestSettings.GetCldrFileInputDirectoryPath(), patterns);
         }
 
         [Fact]

--- a/src/PageUp.CldrPackager.Test/TestSettings.cs
+++ b/src/PageUp.CldrPackager.Test/TestSettings.cs
@@ -1,7 +1,18 @@
-﻿namespace PageUp.CldrPackager.Test
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace PageUp.CldrPackager.Test
 {
     public static class TestSettings
     {
-        public const string CldrFileInputDirectory = "node_modules/@pageup/locale/cldr";
+        private const string CldrFileInputDirectory = "node_modules/@pageup/locale/cldr";
+
+        public static string GetCldrFileInputDirectoryPath()
+        {
+            return new Uri(Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase),
+                CldrFileInputDirectory)).LocalPath;
+        }
     }
 }

--- a/src/PageUp.CldrPackager/PageUp.CldrPackager.csproj
+++ b/src/PageUp.CldrPackager/PageUp.CldrPackager.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>


### PR DESCRIPTION
Fixed the broken build.

Tests failed because the working directory was not the same as the directory that the executable was run from. This was fixed by forcing the tests to use the path the code is stored at instead.

Build failed because:
 - Write-access errors when restoring npm packages (sometimes). This is a known issue with appveyor that was especially common in old versions of npm. Turns out the default version of node/npm is 3 LTS versions old. Build has been updated to pull the latest node/npm versions during the setup phase.
 - AppVeyor was running default test behaviour. This runds the tests again after our custom script does. But AppVeyor tries to be smart and cleans out the extra node_modules files after build and before test execution. To stop this from happening I moved the test step of the build into the test_script phase, which prevents AppVeyor's default testing.

**I have also incremented the build to `1.0.3`.** This will auto deploy after pull request is merged.